### PR TITLE
Fix typo

### DIFF
--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -25,7 +25,7 @@ export default class Base {
     service: '',
     serviceVersion: '',
     pagePath: '',
-    category: ErrorsCategory.UNKNOW_ERROR,
+    category: ErrorsCategory.UNKNOWN_ERROR,
     grade: GradeTypeEnum.INFO,
     errorUrl: '',
     line: 0,

--- a/src/services/constant.ts
+++ b/src/services/constant.ts
@@ -1,4 +1,4 @@
-import Report from "./report";
+import Report from './report';
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -17,12 +17,12 @@ import Report from "./report";
  * limitations under the License.
  */
 export enum ErrorsCategory {
-  AJAX_ERROR = 'ajaxError',
-  RESOURCE_ERROR = 'resourceError',
-  VUE_ERROR = 'vueError',
-  PROMISE_ERROR = 'promiseError',
-  JS_ERROR = 'jsError',
-  UNKNOW_ERROR = 'unknowError',
+  AJAX_ERROR = 'ajax',
+  RESOURCE_ERROR = 'resource',
+  VUE_ERROR = 'vue',
+  PROMISE_ERROR = 'promise',
+  JS_ERROR = 'js',
+  UNKNOWN_ERROR = 'unknown',
 }
 export enum GradeTypeEnum {
   INFO = 'Info',


### PR DESCRIPTION
Update the `ErrorsCategory` to be consistent with the [backend](https://github.com/apache/skywalking-data-collect-protocol/blob/master/browser/BrowserPerf.proto#L101).


## screenshots
![image](https://user-images.githubusercontent.com/26432832/95674871-aba3ff00-0be5-11eb-9420-e4703246f4ca.png)

