### PR TITLE
Remove unused filed

### DIFF
--- a/src/errors/ajax.ts
+++ b/src/errors/ajax.ts
@@ -38,10 +38,6 @@ class AjaxErrors extends Base {
             grade: GradeTypeEnum.ERROR,
             errorUrl: event.target.responseURL,
             message: event.target.response,
-            errorInfo: {
-              status: event.target.status,
-              statusText: event.target.statusText,
-            },
             collector: options.collector,
           };
           this.traceInfo();

--- a/src/errors/js.ts
+++ b/src/errors/js.ts
@@ -31,7 +31,6 @@ class JSErrors extends Base {
         errorUrl: url,
         line,
         col,
-        errorInfo: error,
         message,
         collector: options.collector,
       };

--- a/src/errors/promise.ts
+++ b/src/errors/promise.ts
@@ -39,7 +39,6 @@ class PromiseErrors extends Base {
           grade: GradeTypeEnum.ERROR,
           errorUrl: url,
           message: event.reason,
-          errorInfo: event.reason,
           collector: options.collector,
         };
         this.traceInfo();

--- a/src/errors/resource.ts
+++ b/src/errors/resource.ts
@@ -44,7 +44,6 @@ class ResourceErrors extends Base {
           category: ErrorsCategory.RESOURCE_ERROR,
           grade: target.tagName === 'IMG' ? GradeTypeEnum.WARNING : GradeTypeEnum.ERROR,
           errorUrl: target.src || target.href,
-          errorInfo: target,
           message: `load ${target.tagName} resource error`,
           collector: options.collector,
         };

--- a/src/errors/vue.ts
+++ b/src/errors/vue.ts
@@ -34,7 +34,6 @@ class VueErrors extends Base {
           category: ErrorsCategory.VUE_ERROR,
           grade: GradeTypeEnum.ERROR,
           errorUrl: '',
-          errorInfo: error,
           message: info,
           collector: options.collector,
         };

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -30,7 +30,6 @@ export default class Base {
     errorUrl: '',
     line: 0,
     col: 0,
-    errorInfo: '',
     message: '',
     firstReportedError: false,
     collector: '',

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -21,7 +21,7 @@ export interface ErrorInfoFeilds {
   grade: string;
   message: any;
   errorUrl: string;
-  line?: number; 
+  line?: number;
   col?: number;
   errorInfo?: any;
   firstReportedError?: boolean;


### PR DESCRIPTION
`erroInfo` is not a field defined in the [BrowserErrorLog](https://github.com/apache/skywalking-data-collect-protocol/blob/master/browser/BrowserPerf.proto#L79).

## screenshots
![image](https://user-images.githubusercontent.com/26432832/96200498-a69bd280-0f8c-11eb-9598-251a9345bc67.png)
![image](https://user-images.githubusercontent.com/26432832/96200505-a8659600-0f8c-11eb-8739-40a9fe833ae1.png)
