### PR TITLE
add originAllowlist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The register method supports the following parameters.
 |vue|Vue|Support vue errors monitoring|false|undefined|
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
+|originAllowlist|string \| RegExp \| (string \| RegExp)[]|Only the request origin on this list will be tracked.|false|-|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -51,17 +51,19 @@ export default function traceSegment(options: CustomOptionsType) {
         options.originWhitelist = [options.originWhitelist];
       }
 
-      for (const rule of options.originWhitelist) {
+      const traced = options.originWhitelist.some((rule) => {
         if (typeof rule === 'string') {
           if (rule === url.origin) {
-            return;
+            return true;
           }
         } else if (rule instanceof RegExp) {
           if (rule.test(url.origin)) {
-            return;
+            return true;
           }
         }
-      }
+      });
+
+      if (!traced) return;
     }
     if (
       ([ReportTypes.ERROR, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(url.pathname) &&

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -46,12 +46,12 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
-    if (options.originWhitelist) {
-      if (!Array.isArray(options.originWhitelist)) {
-        options.originWhitelist = [options.originWhitelist];
+    if (options.originAllowlist) {
+      if (!Array.isArray(options.originAllowlist)) {
+        options.originAllowlist = [options.originAllowlist];
       }
 
-      const traced = options.originWhitelist.some((rule) => {
+      const traced = options.originAllowlist.some((rule) => {
         if (typeof rule === 'string') {
           if (rule === url.origin) {
             return true;

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -46,6 +46,23 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
+    if (options.originWhitelist) {
+      if (!Array.isArray(options.originWhitelist)) {
+        options.originWhitelist = [options.originWhitelist];
+      }
+
+      for (const rule of options.originWhitelist) {
+        if (typeof rule === 'string') {
+          if (rule === url.origin) {
+            return;
+          }
+        } else if (rule instanceof RegExp) {
+          if (rule.test(url.origin)) {
+            return;
+          }
+        }
+      }
+    }
     if (
       ([ReportTypes.ERROR, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(url.pathname) &&
       !options.traceSDKInternal

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,5 +29,5 @@ export interface CustomOptionsType {
   vue?: any;
   traceSDKInternal?: boolean;
   detailMode?: boolean;
-  originWhitelist?: string | RegExp | (string | RegExp)[];
+  originAllowlist?: string | RegExp | (string | RegExp)[];
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,4 +29,5 @@ export interface CustomOptionsType {
   vue?: any;
   traceSDKInternal?: boolean;
   detailMode?: boolean;
+  originWhitelist?: string | RegExp | (string | RegExp)[];
 }


### PR DESCRIPTION
Add originAllowlist option, only the request origin on this list will be tracked.

```js
import ClientMonitor from 'skywalking-client-js';

ClientMonitor.setPerformance({
  collector: 'http://127.0.0.1:8080',
  service: 'browser-app',
  serviceVersion: '1.0.0',
  pagePath: location.href,
  useFmp: true,
  originAllowlist: ['http://example1.com', /\.example2\.com$/]
});
```