### PR TITLE
add `noTraceOrigins` option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The register method supports the following parameters.
 |vue|Vue|Support vue errors monitoring|false|undefined|
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
-|traceOrigins|string \| RegExp \| (string \| RegExp)[]|Only the request origin on this list will be tracked.|false|-|
+|originAllowList|(string \| RegExp)[]|The allow list to determine activating tracing.|false|-|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The register method supports the following parameters.
 |vue|Vue|Support vue errors monitoring|false|undefined|
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
-|originAllowList|(string \| RegExp)[]|The allow list to determine activating tracing.|false|-|
+|noTraceOrigins|(string \| RegExp)[]|Origin in the `noTraceOrigins` list will not be traced.|false|-|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The register method supports the following parameters.
 |vue|Vue|Support vue errors monitoring|false|undefined|
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
+|originAllowlist|string \| RegExp \| (string \| RegExp)[]|Only the request origin on this list will be tracked.|false|-|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.
@@ -62,7 +63,7 @@ Use the `setPerformance` method to report metrics at the moment of page loaded o
 2. Call `ClientMonitor.setPerformance(object)` method to report
 
 - Examples
-```
+```js
 import ClientMonitor from 'skywalking-client-js';
 
 ClientMonitor.setPerformance({

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The register method supports the following parameters.
 |vue|Vue|Support vue errors monitoring|false|undefined|
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
-|noTraceOrigins|(string \| RegExp)[]|Origin in the `noTraceOrigins` list will not be traced.|false|-|
+|noTraceOrigins|(string \| RegExp)[]|Origin in the `noTraceOrigins` list will not be traced.|false|[]|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ npm install skywalking-client-js --save
 
 User could use `register` method to load and report data automatically.
 
-```
+```js
 import ClientMonitor from 'skywalking-client-js';
 ```
-```
+```js
 // Report collected data to `http:// + window.location.host + /browser/perfData` in default
 ClientMonitor.register({
   collector: 'http://127.0.0.1:8080',
@@ -54,7 +54,7 @@ The register method supports the following parameters.
 |vue|Vue|Support vue errors monitoring|false|undefined|
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
-|originAllowlist|string \| RegExp \| (string \| RegExp)[]|Only the request origin on this list will be tracked.|false|-|
+|traceOrigins|string \| RegExp \| (string \| RegExp)[]|Only the request origin on this list will be tracked.|false|-|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -31,6 +31,7 @@ const ClientMonitor = {
     enableSPA: false,
     traceSDKInternal: false,
     detailMode: true,
+    noTraceOrigins: [],
   } as CustomOptionsType,
 
   register(configs: CustomOptionsType) {

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -46,6 +46,25 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
+    if (options.originAllowlist) {
+      if (!Array.isArray(options.originAllowlist)) {
+        options.originAllowlist = [options.originAllowlist];
+      }
+
+      const traced = options.originAllowlist.some((rule) => {
+        if (typeof rule === 'string') {
+          if (rule === url.origin) {
+            return true;
+          }
+        } else if (rule instanceof RegExp) {
+          if (rule.test(url.origin)) {
+            return true;
+          }
+        }
+      });
+
+      if (!traced) return;
+    }
     if (
       ([ReportTypes.ERROR, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(url.pathname) &&
       !options.traceSDKInternal

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -48,12 +48,8 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
-    if (options.traceOrigins) {
-      if (!Array.isArray(options.traceOrigins)) {
-        options.traceOrigins = [options.traceOrigins];
-      }
-
-      const traced = options.traceOrigins.some((rule) => {
+    if (Array.isArray(options.originAllowList)) {
+      const traced = options.originAllowList.some((rule) => {
         if (typeof rule === 'string') {
           if (rule === url.origin) {
             return true;

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -48,12 +48,12 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
-    if (options.originAllowlist) {
-      if (!Array.isArray(options.originAllowlist)) {
-        options.originAllowlist = [options.originAllowlist];
+    if (options.traceOrigins) {
+      if (!Array.isArray(options.traceOrigins)) {
+        options.traceOrigins = [options.traceOrigins];
       }
 
-      const traced = options.originAllowlist.some((rule) => {
+      const traced = options.traceOrigins.some((rule) => {
         if (typeof rule === 'string') {
           if (rule === url.origin) {
             return true;

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -48,8 +48,8 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
-    if (Array.isArray(options.originAllowList)) {
-      const traced = options.originAllowList.some((rule) => {
+    if (Array.isArray(options.noTraceOrigins)) {
+      const noTrace = options.noTraceOrigins.some((rule) => {
         if (typeof rule === 'string') {
           if (rule === url.origin) {
             return true;
@@ -61,7 +61,7 @@ export default function traceSegment(options: CustomOptionsType) {
         }
       });
 
-      if (!traced) return;
+      if (noTrace) return;
     }
     if (
       ([ReportTypes.ERROR, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(url.pathname) &&

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -48,21 +48,22 @@ export default function traceSegment(options: CustomOptionsType) {
       url = new URL(window.location.href);
       url.pathname = config[1];
     }
-    if (Array.isArray(options.noTraceOrigins)) {
-      const noTrace = options.noTraceOrigins.some((rule) => {
-        if (typeof rule === 'string') {
-          if (rule === url.origin) {
-            return true;
-          }
-        } else if (rule instanceof RegExp) {
-          if (rule.test(url.origin)) {
-            return true;
-          }
-        }
-      });
 
-      if (noTrace) return;
+    const noTrace = options.noTraceOrigins.some((rule) => {
+      if (typeof rule === 'string') {
+        if (rule === url.origin) {
+          return true;
+        }
+      } else if (rule instanceof RegExp) {
+        if (rule.test(url.origin)) {
+          return true;
+        }
+      }
+    });
+    if (noTrace) {
+      return;
     }
+
     if (
       ([ReportTypes.ERROR, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(url.pathname) &&
       !options.traceSDKInternal

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,5 +29,5 @@ export interface CustomOptionsType {
   vue?: any;
   traceSDKInternal?: boolean;
   detailMode?: boolean;
-  originAllowList?: (string | RegExp)[];
+  noTraceOrigins?: (string | RegExp)[];
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,5 +29,5 @@ export interface CustomOptionsType {
   vue?: any;
   traceSDKInternal?: boolean;
   detailMode?: boolean;
-  originAllowlist?: string | RegExp | (string | RegExp)[];
+  traceOrigins?: string | RegExp | (string | RegExp)[];
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,5 +29,5 @@ export interface CustomOptionsType {
   vue?: any;
   traceSDKInternal?: boolean;
   detailMode?: boolean;
-  traceOrigins?: string | RegExp | (string | RegExp)[];
+  originAllowList?: (string | RegExp)[];
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,4 +29,5 @@ export interface CustomOptionsType {
   vue?: any;
   traceSDKInternal?: boolean;
   detailMode?: boolean;
+  originAllowlist?: string | RegExp | (string | RegExp)[];
 }


### PR DESCRIPTION
Now, the SDK will intercept all `XHR` requests and add `ws8` request headers. In the cross-domain, the server needs to add headers.

```
Access-Control-Allow-Headers: ws8
```

<https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests>

In some cases, we may request third party services. If a third party server does not add the top header, there will be cross-domain problems.

@wu-sheng 

Add `originAllowlist` option, only the request origin on this list will be tracked.

```js
import ClientMonitor from 'skywalking-client-js';

ClientMonitor.setPerformance({
  collector: 'http://127.0.0.1:8080',
  service: 'browser-app',
  serviceVersion: '1.0.0',
  pagePath: location.href,
  useFmp: true,
  noTraceOrigins: ['http://example1.com', /\.example2\.com$/]
});
```