### PR TITLE
fix: wrong URL when using relative path

### DIFF
--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -40,8 +40,10 @@ export default function traceSegment(options: CustomOptionsType) {
     const xhrState = event.detail.readyState;
     const config = event.detail.getRequestConfig;
     let url = {} as URL;
-    if (config[1].startsWith('http://') || config[1].startsWith('https://') || config[1].startsWith('//')) {
+    if (config[1].startsWith('http://') || config[1].startsWith('https://')) {
       url = new URL(config[1]);
+    } else if (config[1].startsWith('//')) {
+      url = new URL(`${location.protocol}${config[1]}`);
     } else {
       url = new URL(window.location.href);
       url.pathname = config[1];

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -43,7 +43,7 @@ export default function traceSegment(options: CustomOptionsType) {
     if (config[1].startsWith('http://') || config[1].startsWith('https://')) {
       url = new URL(config[1]);
     } else if (config[1].startsWith('//')) {
-      url = new URL(`${location.protocol}${config[1]}`);
+      url = new URL(`${window.location.protocol}${config[1]}`);
     } else {
       url = new URL(window.location.href);
       url.pathname = config[1];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3387702/110072284-7d070a80-7db8-11eb-84cc-3ceda172e767.png)

Fix the ellipsis protocol for errors, as shown below
```js
fetch('//example.com');
```