### PR TITLE
feat: Support reporting multiple logs

### DIFF
--- a/src/errors/ajax.ts
+++ b/src/errors/ajax.ts
@@ -29,6 +29,8 @@ class AjaxErrors extends Base {
     const xhrEvent = (event: any) => {
       try {
         if (event && event.currentTarget && (event.currentTarget.status >= 400 || event.currentTarget.status === 0)) {
+          const response = 'net::ERR_EMPTY_RESPONSE';
+
           this.logInfo = {
             uniqueId: uuid(),
             service: options.service,
@@ -36,10 +38,10 @@ class AjaxErrors extends Base {
             pagePath: options.pagePath,
             category: ErrorsCategory.AJAX_ERROR,
             grade: GradeTypeEnum.ERROR,
-            errorUrl: event.target.responseURL,
-            message: event.target.response,
+            errorUrl: event.target.getRequestConfig[1],
+            message: event.target.response || response,
             collector: options.collector,
-            stack: event.type + ':' + event.target.response,
+            stack: event.type + ': ' + (event.target.response || response),
           };
           this.traceInfo();
         }

--- a/src/errors/ajax.ts
+++ b/src/errors/ajax.ts
@@ -17,7 +17,7 @@
 
 import uuid from '../services/uuid';
 import Base from '../services/base';
-import { GradeTypeEnum, ErrorsCategory } from '../services/constant';
+import { GradeTypeEnum, ErrorsCategory, ReportTypes } from '../services/constant';
 
 class AjaxErrors extends Base {
   // get http error info
@@ -31,6 +31,9 @@ class AjaxErrors extends Base {
         if (event && event.currentTarget && (event.currentTarget.status >= 400 || event.currentTarget.status === 0)) {
           const response = 'net::ERR_EMPTY_RESPONSE';
 
+          if (event.target && event.target.getRequestConfig[1] === options.collector + ReportTypes.ERRORS) {
+            return;
+          }
           this.logInfo = {
             uniqueId: uuid(),
             service: options.service,

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -41,17 +41,13 @@ export default class Base {
       jsErrorPv = true;
       this.logInfo.firstReportedError = true;
     }
-    this.handleRecordError();
+    const collector = this.logInfo.collector;
+
+    delete this.logInfo.collector;
+    Task.addTask(this.logInfo, collector);
+
     setTimeout(() => {
       Task.fireTasks();
-    }, 100);
-  }
-
-  private handleRecordError() {
-    try {
-      Task.addTask(this.logInfo);
-    } catch (error) {
-      throw error;
-    }
+    }, 60000);
   }
 }

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -49,33 +49,9 @@ export default class Base {
 
   private handleRecordError() {
     try {
-      if (!this.logInfo.message) {
-        return;
-      }
-      const errorInfo = this.handleErrorInfo();
-
-      Task.addTask(errorInfo);
+      Task.addTask(this.logInfo);
     } catch (error) {
       throw error;
     }
-  }
-
-  private handleErrorInfo() {
-    let message = `error category:${this.logInfo.category}\r\n log info:${this.logInfo.message}\r\n
-      error url: ${this.logInfo.errorUrl}\r\n `;
-
-    switch (this.logInfo.category) {
-      case ErrorsCategory.JS_ERROR:
-        message += `error line number: ${this.logInfo.line}\r\n error col number:${this.logInfo.col}\r\n`;
-        break;
-      default:
-        message;
-        break;
-    }
-    const recordInfo = {
-      ...this.logInfo,
-      message,
-    };
-    return recordInfo;
   }
 }

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -45,7 +45,7 @@ export default class Base {
 
     delete this.logInfo.collector;
     Task.addTask(this.logInfo, collector);
-
+    // report errors within 1min
     setTimeout(() => {
       Task.fireTasks();
     }, 60000);

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -51,7 +51,6 @@ class Report {
   }
 
   public sendByXhr(data: any) {
-    delete data.collector;
     if (!this.url) {
       return;
     }

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -30,7 +30,7 @@ class TaskQueue {
     if (!(this.queues && this.queues.length)) {
       return;
     }
-    new Report('ERROR', this.collector).sendByXhr(this.queues);
+    new Report('ERRORS', this.collector).sendByXhr(this.queues);
     this.queues = [];
   }
 }

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -14,23 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ErrorInfoFeilds, ReportFields } from './types';
 import Report from './report';
 
 class TaskQueue {
-  private queues: any[] = [];
+  private queues: ((ErrorInfoFeilds & ReportFields) | undefined)[] = [];
+  private collector: string = '';
 
-  public addTask(data: any) {
-    this.queues.push({ data });
+  public addTask(data: ErrorInfoFeilds & ReportFields, collector: string) {
+    this.queues.push(data);
+    this.collector = collector;
   }
 
   public fireTasks() {
-    if (!this.queues || !this.queues.length) {
+    if (!(this.queues && this.queues.length)) {
       return;
     }
-    const item = this.queues[0];
-    new Report('ERROR', item.data.collector).sendByXhr(item.data);
-    this.queues.splice(0, 1);
-    this.fireTasks();
+    new Report('ERROR', this.collector).sendByXhr(this.queues);
+    this.queues = [];
   }
 }
 

--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -73,6 +73,10 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
         const index = segment.spans.length;
         const values = `${1}-${traceIdStr}-${segmentId}-${index}-${service}-${instance}-${endpoint}-${peer}`;
 
+        if (!args[1]) {
+          args[1] = {};
+          args[1].headers = {};
+        }
         args[1].headers['sw8'] = values;
       }
 


### PR DESCRIPTION
Support reporting multiple logs within 1min.
Fix circular reporting error, when the `collector` serve doesn't work.
Update message in logs.

Screenshot
![1](https://user-images.githubusercontent.com/20871783/115534361-459de000-a2ca-11eb-8fb5-bdcf9147c711.png)

Singed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
