### PR TITLE
feat: add report interval params to register method

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The register method supports the following parameters.
 |traceSDKInternal|Boolean|Support tracing SDK internal RPC.|false|false|
 |detailMode|Boolean|Support tracing http method and url as tags in spans.|false|true|
 |noTraceOrigins|(string \| RegExp)[]|Origin in the `noTraceOrigins` list will not be traced.|false|[]|
+|autoReportInterval|Number| Interval millseconds used for reporting segments.|false|300000|
 
 ## Collect Metrics Manually
 Use the `setPerformance` method to report metrics at the moment of page loaded or any other moment meaningful.

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -50,13 +50,13 @@ class Report {
       });
   }
 
-  public sendByXhr(data: any) {
+  public sendByXhr(data: any, async: boolean = true) {
     if (!this.url) {
       return;
     }
     const xhr = new XMLHttpRequest();
 
-    xhr.open('post', this.url, true);
+    xhr.open('post', this.url, async);
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.onreadystatechange = function () {
       if (xhr.readyState === 4 && xhr.status < 400) {

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -40,5 +40,5 @@ export default function traceSegment(options: CustomOptionsType) {
     }
     new Report('SEGMENTS', options.collector).sendByXhr(segments);
     segments = [];
-  }, 300000);
+  }, options.autoReportInterval || 300000);
 }

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -31,7 +31,7 @@ export default function traceSegment(options: CustomOptionsType) {
     if (!segments.length) {
       return;
     }
-    new Report('SEGMENTS', options.collector).sendByXhr(segments);
+    new Report('SEGMENTS', options.collector).sendByXhr(segments, false);
   };
   //report per 5min
   setInterval(() => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,6 +26,7 @@ export interface CustomOptionsType extends CustomReportOptions {
   traceSDKInternal?: boolean;
   detailMode?: boolean;
   noTraceOrigins?: (string | RegExp)[];
+  autoReportInterval?: number;
 }
 
 export interface CustomReportOptions {


### PR DESCRIPTION
The current `register` method report segment is 5mins, which may be customized by the user.

```typescript
ClientMonitor.register({
  collector: 'http://127.0.0.1:8080',
  service: 'test-ui',
  pagePath: '/current/page/name',
  serviceVersion: 'v1.0.0',
  autoReportInterval: 300000,
});
```