### PR TITLE
fix: reporting errors when close pages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-client-js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Client-side JavaScript exception and tracing library for Apache SkyWalking APM",
   "main": "index.js",
   "repository": "apache/skywalking-client-js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-client-js",
-  "version": "0.5.0",
+  "version": "0.4.0",
   "description": "Client-side JavaScript exception and tracing library for Apache SkyWalking APM",
   "main": "index.js",
   "repository": "apache/skywalking-client-js",

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -45,6 +45,7 @@ export default class Base {
 
     delete this.logInfo.collector;
     Task.addTask(this.logInfo, collector);
+    Task.finallyFireTasks();
     // report errors within 1min
     setTimeout(() => {
       Task.fireTasks();

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -21,15 +21,6 @@ class TaskQueue {
   private queues: ((ErrorInfoFields & ReportFields) | undefined)[] = [];
   private collector: string = '';
 
-  public constructor() {
-    window.onbeforeunload = () => {
-      if (!this.queues.length) {
-        return;
-      }
-      new Report('ERRORS', this.collector).sendByXhr(this.queues);
-    };
-  }
-
   public addTask(data: ErrorInfoFields & ReportFields, collector: string) {
     this.queues.push(data);
     this.collector = collector;
@@ -41,6 +32,15 @@ class TaskQueue {
     }
     new Report('ERRORS', this.collector).sendByXhr(this.queues);
     this.queues = [];
+  }
+
+  public finallyFireTasks() {
+    window.onbeforeunload = () => {
+      if (!this.queues.length) {
+        return;
+      }
+      new Report('ERRORS', this.collector).sendByXhr(this.queues);
+    };
   }
 }
 

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -21,6 +21,15 @@ class TaskQueue {
   private queues: ((ErrorInfoFields & ReportFields) | undefined)[] = [];
   private collector: string = '';
 
+  public constructor() {
+    window.onbeforeunload = () => {
+      if (!this.queues.length) {
+        return;
+      }
+      new Report('ERRORS', this.collector).sendByXhr(this.queues);
+    };
+  }
+
   public addTask(data: ErrorInfoFields & ReportFields, collector: string) {
     this.queues.push(data);
     this.collector = collector;


### PR DESCRIPTION
Fixes reporting errors when close pages to avoid reporting missing logs.

Screenshot
![1](https://user-images.githubusercontent.com/20871783/116525980-af8e3900-a90b-11eb-8a00-97c46c401529.png) 

Signed-off-by: Qiuxia Fan<qiuxiafan@apache.org>
