### PR TITLE
fix: catch errors for http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ app.on('routeChange', function (next) {
 
 ## Tracing range of data requests in the browser
 
-Support tracking these([XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) and [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)) two modes of data requests. At the same time, Support tracking libraries and tools that base on XMLHttpRequest and fetch, such as [Axios](https://github.com/axios/axios), [SuperAgent](https://github.com/visionmedia/superagent), [OpenApi](https://www.openapis.org/) and so on.
+Support tracking these([XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) and [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)) two modes of data requests. At the same time, Support tracking libraries and tools that base on XMLHttpRequest and fetch, such as [Axios](https://github.com/axios/axios), [SuperAgent](https://github.com/visionmedia/superagent), [OpenApi](https://www.openapis.org/) and so on.
 
 ## Catching errors in frames, including React, Angular, Vue.
 

--- a/src/errors/ajax.ts
+++ b/src/errors/ajax.ts
@@ -37,6 +37,9 @@ class AjaxErrors extends Base {
         if (detail.getRequestConfig[1] === options.collector + ReportTypes.ERRORS) {
           return;
         }
+        if (detail.status !== 0 && detail.status < 400) {
+          return;
+        }
 
         this.logInfo = {
           uniqueId: uuid(),
@@ -53,7 +56,6 @@ class AjaxErrors extends Base {
         this.traceInfo();
       },
     );
-    // Fetch API
   }
 }
 

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -35,7 +35,8 @@ export default class Base {
     collector: '',
   };
 
-  public traceInfo() {
+  public traceInfo(logInfo?: ErrorInfoFields & ReportFields & { collector: string }) {
+    this.logInfo = logInfo || this.logInfo;
     // mark js error pv
     if (!jsErrorPv && this.logInfo.category === ErrorsCategory.JS_ERROR) {
       jsErrorPv = true;


### PR DESCRIPTION
Fix catching Ajax errors with Fetch API
Refactor catching Ajax errors with interruptors(Fetch API and XMLHttpRequest)
Refer to https://github.com/apache/skywalking/issues/7166

Screenshot
![1](https://user-images.githubusercontent.com/20871783/124223131-b0bf2a80-db35-11eb-8b8a-2498281e8000.png)

Signed-0ff-by: Qiuxia Fan <qiuxiafan@apache.org>
