### PR TITLE
feat: Use Navigation Timing Level 2 to catch perf data

### DIFF
--- a/src/performance/perf.ts
+++ b/src/performance/perf.ts
@@ -18,11 +18,14 @@ import { IPerfDetail } from './type';
 class PagePerf {
   public getPerfTiming(): IPerfDetail {
     try {
-      if (!window.performance || !window.performance.timing) {
-        console.log('your browser do not support performance');
-        return;
+      let { timing } = window.performance as PerformanceNavigationTiming | any; // PerformanceTiming
+      if (typeof window.PerformanceNavigationTiming === 'function') {
+        const nt2Timing = performance.getEntriesByType('navigation')[0];
+
+        if (nt2Timing) {
+          timing = nt2Timing;
+        }
       }
-      const { timing } = window.performance;
       let redirectTime = 0;
 
       if (timing.navigationStart !== undefined) {

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -33,7 +33,7 @@ export default function traceSegment(options: CustomOptionsType) {
     }
     new Report('SEGMENTS', options.collector).sendByXhr(segments);
   };
-  //report per 5min
+  //report per options.traceTimeInterval min
   setInterval(() => {
     if (!segments.length) {
       return;


### PR DESCRIPTION
The PR use Navigation Timing Level 2 to catch performance data, as the Navigation Timing Level 1(https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming) was deprecated. It gives way to level 2(https://www.w3.org/TR/navigation-timing-2/) with higher precision, more powerful functions and clearer layers.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
