### PR TITLE
fix: update conditions for traceSDKInternal

### DIFF
--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -54,7 +54,7 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
       url.pathname = args[0];
     }
 
-    const noTrace = options.noTraceOrigins.some((rule: string | RegExp) => {
+    const noTraceOrigins = options.noTraceOrigins.some((rule: string | RegExp) => {
       if (typeof rule === 'string') {
         if (rule === url.origin) {
           return true;
@@ -65,15 +65,14 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
         }
       }
     });
-
     const collectorURL = new URL(options.collector);
-    const hasTrace = !(
-      noTrace ||
-      (([ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(
-        url.pathname.replace(new RegExp(`^${collectorURL.pathname}`), ''),
-      ) &&
-        !options.traceSDKInternal)
-    );
+    const pathname =
+      collectorURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${collectorURL.pathname}`), '');
+    const noTraceSDKInternal =
+      ([ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(
+        pathname,
+      ) && !options.traceSDKInternal;
+    const hasTrace = !(noTraceOrigins || noTraceSDKInternal);
 
     if (hasTrace) {
       const traceIdStr = String(encode(traceId));

--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -65,14 +65,11 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
         }
       }
     });
-    const collectorURL = new URL(options.collector);
-    const pathname =
-      collectorURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${collectorURL.pathname}`), '');
-    const noTraceSDKInternal =
-      ([ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(
-        pathname,
-      ) && !options.traceSDKInternal;
-    const hasTrace = !(noTraceOrigins || noTraceSDKInternal);
+    const cURL = new URL(options.collector);
+    const pathname = cURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${cURL.pathname}`), '');
+    const internal = [ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[];
+    const isSDKInternal = internal.includes(pathname);
+    const hasTrace = !noTraceOrigins || (isSDKInternal && options.traceSDKInternal);
 
     if (hasTrace) {
       const traceIdStr = String(encode(traceId));

--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -67,8 +67,8 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
     });
     const cURL = new URL(options.collector);
     const pathname = cURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${cURL.pathname}`), '');
-    const internal = [ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[];
-    const isSDKInternal = internal.includes(pathname);
+    const internals = [ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[];
+    const isSDKInternal = internals.includes(pathname);
     const hasTrace = !noTraceOrigins || (isSDKInternal && options.traceSDKInternal);
 
     if (hasTrace) {

--- a/src/trace/interceptors/xhr.ts
+++ b/src/trace/interceptors/xhr.ts
@@ -101,13 +101,12 @@ export default function xhrInterceptor(options: CustomOptionsType, segments: Seg
       return;
     }
 
-    const collectorURL = new URL(options.collector);
-    const name =
-      collectorURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${collectorURL.pathname}`), '');
-    const noTraceSDKInternal =
-      ([ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(name) &&
-      !options.traceSDKInternal;
-    if (noTraceSDKInternal) {
+    const cURL = new URL(options.collector);
+    const pathname = cURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${cURL.pathname}`), '');
+    const internal = [ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[];
+    const isSDKInternal = internal.includes(pathname);
+
+    if (isSDKInternal && !options.traceSDKInternal) {
       return;
     }
 

--- a/src/trace/interceptors/xhr.ts
+++ b/src/trace/interceptors/xhr.ts
@@ -103,8 +103,8 @@ export default function xhrInterceptor(options: CustomOptionsType, segments: Seg
 
     const cURL = new URL(options.collector);
     const pathname = cURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${cURL.pathname}`), '');
-    const internal = [ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[];
-    const isSDKInternal = internal.includes(pathname);
+    const internals = [ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[];
+    const isSDKInternal = internals.includes(pathname);
 
     if (isSDKInternal && !options.traceSDKInternal) {
       return;

--- a/src/trace/interceptors/xhr.ts
+++ b/src/trace/interceptors/xhr.ts
@@ -86,7 +86,7 @@ export default function xhrInterceptor(options: CustomOptionsType, segments: Seg
       url.pathname = config[1];
     }
 
-    const noTrace = options.noTraceOrigins.some((rule: string | RegExp) => {
+    const noTraceOrigins = options.noTraceOrigins.some((rule: string | RegExp) => {
       if (typeof rule === 'string') {
         if (rule === url.origin) {
           return true;
@@ -97,17 +97,17 @@ export default function xhrInterceptor(options: CustomOptionsType, segments: Seg
         }
       }
     });
-    if (noTrace) {
+    if (noTraceOrigins) {
       return;
     }
 
-    const collectorURL = new URL(options.collector)
-    if (
-      ([ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(
-        url.pathname.replace(new RegExp(`^${collectorURL.pathname}`), ''),
-      ) &&
-      !options.traceSDKInternal
-    ) {
+    const collectorURL = new URL(options.collector);
+    const name =
+      collectorURL.pathname === '/' ? url.pathname : url.pathname.replace(new RegExp(`^${collectorURL.pathname}`), '');
+    const noTraceSDKInternal =
+      ([ReportTypes.ERROR, ReportTypes.ERRORS, ReportTypes.PERF, ReportTypes.SEGMENTS] as string[]).includes(name) &&
+      !options.traceSDKInternal;
+    if (noTraceSDKInternal) {
       return;
     }
 


### PR DESCRIPTION
Since the pr (https://github.com/apache/skywalking-client-js/pull/68) ignores a scenario, the `traceSDKInternal` is invalid when the path name of collector url is `/`. This pr can fix it.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

