### PR TITLE
fix: update firstReportedError for SPA

### DIFF
--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -45,7 +45,9 @@ export default class Base {
     ];
     // mark js error pv
     if (!pageHasjsError[location.href] && !ExcludeErrorTypes.includes(this.logInfo.category)) {
-      pageHasjsError[location.href] = true;
+      pageHasjsError = {
+        [location.href]: true,
+      };
       this.logInfo.firstReportedError = true;
     }
     const collector = this.logInfo.collector;

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -18,8 +18,8 @@ import Task from './task';
 import { ErrorsCategory, GradeTypeEnum } from './constant';
 import { ErrorInfoFields, ReportFields } from './types';
 
-let jsErrorPv = false;
-let interval: any;
+let pageHasjsError: { [key: string]: boolean } = {};
+let interval: NodeJS.Timeout;
 export default class Base {
   public logInfo: ErrorInfoFields & ReportFields & { collector: string } = {
     uniqueId: '',
@@ -44,8 +44,8 @@ export default class Base {
       ErrorsCategory.UNKNOWN_ERROR,
     ];
     // mark js error pv
-    if (!jsErrorPv && !ExcludeErrorTypes.includes(this.logInfo.category)) {
-      jsErrorPv = true;
+    if (!pageHasjsError[location.href] && !ExcludeErrorTypes.includes(this.logInfo.category)) {
+      pageHasjsError[location.href] = true;
       this.logInfo.firstReportedError = true;
     }
     const collector = this.logInfo.collector;


### PR DESCRIPTION
This PR fixes `firstReportedError` don't be marked `true`, when the route has changed in SPA scenario.

Screenshots
![1](https://user-images.githubusercontent.com/20871783/134809034-26bb5c39-531e-4b8f-bf24-340ef14dee50.png)
![2](https://user-images.githubusercontent.com/20871783/134809056-af063401-a504-4158-9073-d74c611207d3.png)

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

