### PR TITLE
Solution `cannot get window.performance data` bug about concurrently call ClientMonitor#register and ClientMonitor#setPerformance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ ClientMonitor.setPerformance({
   service: 'browser-app',
   serviceVersion: '1.0.0',
   pagePath: location.href,
-  useFmp: true
+  useFmp: true,
+  autoTracePerf: true,
 });
 ```
 

--- a/src/performance/index.ts
+++ b/src/performance/index.ts
@@ -26,16 +26,17 @@ class TracePerf {
     perfDetail: {},
   } as { perfDetail: IPerfDetail };
 
-  public async recordPerf(options: CustomOptionsType) {
-    let fmp: { fmpTime: number | undefined } = { fmpTime: undefined };
-    if (options.autoTracePerf) {
-      this.perfConfig.perfDetail = await new pagePerf().getPerfTiming();
-      if (options.useFmp) {
-        fmp = await new FMP();
-      }
-    }
+  public recordPerf(options: CustomOptionsType) {
     // auto report pv and perf data
     setTimeout(() => {
+      let fmp: { fmpTime: number | undefined } = { fmpTime: undefined };
+      if (options.autoTracePerf) {
+        this.perfConfig.perfDetail = new pagePerf().getPerfTiming();
+        if (options.useFmp) {
+          fmp = new FMP();
+        }
+      }
+
       const perfDetail = options.autoTracePerf
         ? {
             ...this.perfConfig.perfDetail,


### PR DESCRIPTION
…call ClientMonitor.setPerformance() need to set param autoTracePerf is true.

2.at the same time ClientMonitor.register() and ClientMonitor.setPerformance() due to  window.performance data is cleared after the first setTimeout execute completed,so second setTimeout cannot get data.