### PR TITLE
feat: report data by `navigator.sendbeacon` when the event is `beforeunload`

### DIFF
--- a/src/errors/promise.ts
+++ b/src/errors/promise.ts
@@ -42,6 +42,7 @@ class PromiseErrors extends Base {
           stack: event.reason.stack,
           collector: options.collector,
         };
+        // console.log({ options })
         this.traceInfo();
       } catch (error) {
         console.log(error);

--- a/src/errors/promise.ts
+++ b/src/errors/promise.ts
@@ -42,7 +42,7 @@ class PromiseErrors extends Base {
           stack: event.reason.stack,
           collector: options.collector,
         };
-        // console.log({ options })
+
         this.traceInfo();
       } catch (error) {
         console.log(error);

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -65,5 +65,17 @@ class Report {
     };
     xhr.send(JSON.stringify(data));
   }
+
+  public sendByBeacon(data: any) {
+    if (!this.url) {
+      return;
+    }
+    if (typeof navigator.sendBeacon === 'function') {
+      navigator.sendBeacon(this.url, JSON.stringify(data));
+      return;
+    }
+
+    this.sendByXhr(data);
+  }
 }
 export default Report;

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -30,7 +30,7 @@ class TaskQueue {
     if (!(this.queues && this.queues.length)) {
       return;
     }
-    // console.log('queues:', this.queues)
+
     new Report('ERRORS', this.collector).sendByXhr(this.queues);
     this.queues = [];
   }

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -30,6 +30,7 @@ class TaskQueue {
     if (!(this.queues && this.queues.length)) {
       return;
     }
+    // console.log('queues:', this.queues)
     new Report('ERRORS', this.collector).sendByXhr(this.queues);
     this.queues = [];
   }
@@ -39,7 +40,7 @@ class TaskQueue {
       if (!this.queues.length) {
         return;
       }
-      new Report('ERRORS', this.collector).sendByXhr(this.queues);
+      new Report('ERRORS', this.collector).sendByBeacon(this.queues);
     };
   }
 }

--- a/src/trace/segment.ts
+++ b/src/trace/segment.ts
@@ -31,7 +31,7 @@ export default function traceSegment(options: CustomOptionsType) {
     if (!segments.length) {
       return;
     }
-    new Report('SEGMENTS', options.collector).sendByXhr(segments);
+    new Report('SEGMENTS', options.collector).sendByBeacon(segments);
   };
   //report per options.traceTimeInterval min
   setInterval(() => {


### PR DESCRIPTION
when using xhr send request in window.onbeforeunload, the request can't send successfully. so i add navigator.sendbeacon in order to sending request  in window.onbeforeunload.