### PR TITLE
support to "import ClientMonitor from 'skywalking-client-js' in "typescript" and "es6"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+export as namespace ClientMonitor;
+
+export interface ClientMonitorConfig {
+    collector?: string;
+    service: string;
+    serviceVersion: string;
+    pagePath: string;
+    jsErrors?: boolean;
+    apiErrors?: boolean;
+    resourceErrors?: boolean;
+    useFmp?: boolean;
+    enableSPA?: boolean;
+    autoTracePerf?: boolean;
+    vue?: Vue;
+    traceSDKInternal?: boolean;
+    detailMode?: boolean;
+    noTraceOrigins?: (string | RegExp)[];
+    traceTimeInterval?: number;
+}
+
+export function register(config: ClientMonitorConfig): void;


### PR DESCRIPTION
support to "import ClientMonitor from 'skywalking-client-js';" when we use the "typescript" and "es6".