### PR TITLE
support to "import ClientMonitor from 'skywalking-client-js'" in "typescript" and "es6"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install and build
+    - name: yarn install and build
       run: |
-        npm ci
+        rm -rf node_modules && yarn install --frozen-lockfile
         npm run build --if-present
       env:
         CI: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export interface ClientMonitorConfig {
     useFmp?: boolean;
     enableSPA?: boolean;
     autoTracePerf?: boolean;
-    vue?: Vue;
+    vue?: any;
     traceSDKInternal?: boolean;
     detailMode?: boolean;
     noTraceOrigins?: (string | RegExp)[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,19 @@
-/*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 export as namespace ClientMonitor;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,24 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+export as namespace ClientMonitor;
+
 export interface ClientMonitorConfig {
     collector?: string;
     service: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-export as namespace ClientMonitor;
-
 export interface ClientMonitorConfig {
     collector?: string;
     service: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+export as namespace ClientMonitor;
+
+export interface ClientMonitorConfig {
+    collector?: string;
+    service: string;
+    serviceVersion: string;
+    pagePath: string;
+    jsErrors?: boolean;
+    apiErrors?: boolean;
+    resourceErrors?: boolean;
+    useFmp?: boolean;
+    enableSPA?: boolean;
+    autoTracePerf?: boolean;
+    vue?: Vue;
+    traceSDKInternal?: boolean;
+    detailMode?: boolean;
+    noTraceOrigins?: (string | RegExp)[];
+    traceTimeInterval?: number;
+}
+
+export function register(config: ClientMonitorConfig): void;

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "ts-loader": "^9.2.1",
     "tslint": "^5.20.1",
     "typescript": "^3.7.2",
-    "webpack": "^4.30.0",
-    "webpack-cli": "^3.3.2",
+    "webpack": "^5.37.0",
+    "webpack-cli": "^3.3.10",
     "webpack-concat-files-plugin": "^0.5.2",
     "webpack-dev-middleware": "^3.7.2",
     "webpack-dev-server": "^3.11.2"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "CHANGES.md",
     "README.md",
     "index.js",
+    "index.d.ts",
     "lib/",
     "dist/licenses"
   ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ts-loader": "^9.2.1",
     "tslint": "^5.20.1",
     "typescript": "^3.7.2",
-    "webpack": "^5.37.0",
+    "webpack": "^5.74.0",
     "webpack-cli": "^3.3.10",
     "webpack-concat-files-plugin": "^0.5.2",
     "webpack-dev-middleware": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "ts-loader": "^9.2.1",
     "tslint": "^5.20.1",
     "typescript": "^3.7.2",
-    "webpack": "^5.74.0",
-    "webpack-cli": "^3.3.10",
+    "webpack": "^4.30.0",
+    "webpack-cli": "^3.3.2",
     "webpack-concat-files-plugin": "^0.5.2",
     "webpack-dev-middleware": "^3.7.2",
     "webpack-dev-server": "^3.11.2"

--- a/tools/check-license-header.py
+++ b/tools/check-license-header.py
@@ -45,7 +45,7 @@ license_header = ' '.join(
 
 comment_leading_chars = ('#', '::', '/*', '*', ' ')
 exclude_dirs = ('.git', 'lib', 'node_modules', 'release', '.idea', 'license')
-exclude_files = ('.md', '.DS_Store', 'NOTICE', 'LICENSE', '.gitignore', 'package.json', 'package-lock.json', '.prettierrc')
+exclude_files = ('.md', '.DS_Store', 'NOTICE', 'LICENSE', '.gitignore', 'package.json', 'package-lock.json', '.prettierrc', 'index.d.ts')
 
 def walk_through_dir(d) -> bool:
     checked = True

--- a/tools/check-license-header.py
+++ b/tools/check-license-header.py
@@ -45,7 +45,7 @@ license_header = ' '.join(
 
 comment_leading_chars = ('#', '::', '/*', '*', ' ')
 exclude_dirs = ('.git', 'lib', 'node_modules', 'release', '.idea', 'license')
-exclude_files = ('.md', '.DS_Store', 'NOTICE', 'LICENSE', '.gitignore', 'package.json', 'package-lock.json', '.prettierrc', 'index.d.ts')
+exclude_files = ('.md', '.DS_Store', 'NOTICE', 'LICENSE', '.gitignore', 'package.json', 'package-lock.json', '.prettierrc')
 
 def walk_through_dir(d) -> bool:
     checked = True


### PR DESCRIPTION
1.Add index.d.ts to the package.json's files.
2.change the index.d.ts , use any type.
3.change the python file , exclude index.d.ts