### PR TITLE
Fixed the bug that navigator.sendBeacon sent json to backend report "No suitable request converter found for a @RequestObject 'List'"

### DIFF
--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -71,7 +71,12 @@ class Report {
       return;
     }
     if (typeof navigator.sendBeacon === 'function') {
-      navigator.sendBeacon(this.url, JSON.stringify(data));
+      navigator.sendBeacon(
+        this.url,
+        new Blob([JSON.stringify(data)], {
+          type: 'application/json'
+        })
+      );
       return;
     }
 


### PR DESCRIPTION
navigator.sendBeacon默认Content-Type为application/x-www-form-urlencoded。会引起后端解析warning。
Failed processing a request:
java.lang.IllegalArgumentException: No suitable request converter found for a @RequestObject 'List'