### PR TITLE
fix: fix reading property from null

### DIFF
--- a/src/performance/fmp.ts
+++ b/src/performance/fmp.ts
@@ -137,13 +137,13 @@ class FMPTiming {
           const index: number = parseInt(item.ele.getAttribute('fmp_c'), 10);
           time = this.statusCollector[index] && this.statusCollector[index].time;
         } else {
-          const match = getStyle(item.ele, 'background-image').match(/url\(\"(.*?)\"\)/);
+          const match = getStyle(item.ele, 'background-image').match(/url\((['"]?)(.*?)\1\)/);
           let url: string = '';
-          if (match && match[1]) {
-            url = match[1];
-          }
-          if (!url.includes('http')) {
-            url = location.protocol + match[1];
+          if (match && match[2]) {
+            url = match[2];
+            if (!url.includes('http')) {
+              url = location.protocol + match[2];
+            }
           }
           time = this.entries[url];
         }


### PR DESCRIPTION
When the match variable is null, the url will be '', and reading match[1] will result in a runtime error. The regular expression does not account for matching URLs with single quotes or URLs without any quotes.