### PR TITLE
fix(trace): append `sw8` to header when using the Header object in queries

### DIFF
--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -83,9 +83,13 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
         args[1] = {};
       }
       if (!args[1].headers) {
-        args[1].headers = {};
+        args[1].headers = new Headers();
       }
-      args[1].headers['sw8'] = values;
+      if (args[1].headers instanceof Headers) {
+        args[1].headers.append('sw8', values);
+      } else {
+        args[1].headers['sw8'] = values;
+      }
     }
 
     const response = await originFetch(...args);


### PR DESCRIPTION
Fixes https://github.com/apache/skywalking/issues/12367

Screenshot

<img width="528" alt="1" src="https://github.com/apache/skywalking-client-js/assets/20871783/57bf639c-8a90-4f81-8ea0-7df1c2c0a2e6">

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
