### PR TITLE
fix(trace): append http method to tags error when using the Header ob…

### DIFF
--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -117,7 +117,7 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
         const tags = [
           {
             key: 'http.method',
-            value: args[1].method || 'GET',
+            value: args[0] instanceof Request ? args[0].method : args[1]?.method || 'GET',
           },
           {
             key: 'url',


### PR DESCRIPTION
> ### Search before asking
> * [x]  I had searched in the [issues](https://github.com/apache/skywalking/issues?q=is%3Aissue) and found no similar issues.
> 
> ### Apache SkyWalking Component
> NodeJS Client Side Agent (apache/skywalking-client-js)
> 
> ### What happened
> Relevant code: https://github.com/apache/skywalking-client-js/blob/master/src/trace/interceptors/fetch.ts#L116-L121
> 
![image](https://github.com/user-attachments/assets/b65bef42-3ecd-45f8-8a02-2028ae6b9a10)

> 
> If we call fetch with a Request object which contains headers, these headers will be throw error if enable skywalking-client-js.
> 
> ```js
> const req = new Request("/api/projects", {
>   headers: {
>     "my-custom-header": "test",
>   },
> });
> 
> fetch(req);
> ```
> 
> ### What you expected to happen
> Fix error
> 
> ### How to reproduce
> https://codesandbox.io/p/devbox/wh2zsm?file=%2Fpackage.json&migrateFrom=sjygtk
> 
> Open the devtools, switch to network tab, filter Fetch/XHR, open details for the request `/api/projects`, in Request Headers,  and switch to console tab , see that  error below
![image](https://github.com/user-attachments/assets/a14dd2fe-0aba-408d-b61e-84e64f57ff06)

![image](https://github.com/user-attachments/assets/fca3b93d-03ec-487d-ba4e-eb090f7780b2)



> 
> ### Anything else
> _No response_
> 
> ### Are you willing to submit a pull request to fix on your own?
> * [x]  Yes I am to submit a pull request on my own!
> 
> ### Code of Conduct
> * [x]  I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct)

