### PR TITLE
fix: The caught fetch request does not work when it receives a URL

### DIFF
--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -38,7 +38,9 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
     } as SegmentFields;
     let url = {} as URL;
     // for args[0] is Request object see: https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
-    if (Object.prototype.toString.call(args[0]) === '[object Request]') {
+    if (Object.prototype.toString.call(args[0]) === '[object URL]') {
+      url = args[0]
+    } else if (Object.prototype.toString.call(args[0]) === '[object Request]') {
       url = new URL(args[0].url);
     } else {
       if (args[0].startsWith('http://') || args[0].startsWith('https://')) {

--- a/src/trace/interceptors/fetch.ts
+++ b/src/trace/interceptors/fetch.ts
@@ -39,7 +39,7 @@ export default function windowFetch(options: CustomOptionsType, segments: Segmen
     let url = {} as URL;
     // for args[0] is Request object see: https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
     if (Object.prototype.toString.call(args[0]) === '[object URL]') {
-      url = args[0]
+      url = args[0];
     } else if (Object.prototype.toString.call(args[0]) === '[object Request]') {
       url = new URL(args[0].url);
     } else {


### PR DESCRIPTION
When part of the framework makes a request for a URL object, it cannot be executed correctly

For example:

fetch(
     new URL('https://xxxx.com')
)